### PR TITLE
ci: automate versioned Homebrew formula (BLDX-1519)

### DIFF
--- a/.github/workflows/versioned-formula.yml
+++ b/.github/workflows/versioned-formula.yml
@@ -1,0 +1,80 @@
+# Add the versioned Homebrew formula automatically (BLDX-1519)
+#
+# The last manual step of the atlan-cli release. GoReleaser (from atlan-cli's
+# create-release.yml) pushes the rolling `Formula/atlan.rb` to the `goreleaser`
+# branch and opens a PR. A human then had to hand-add `Formula/atlan@X.Y.Z.rb`
+# (an exact copy of atlan.rb with the class renamed AtlanATXYZ). This workflow
+# does that commit automatically, onto the same `goreleaser` branch, so it lands
+# in the open GoReleaser PR — ready for a maintainer to merge.
+#
+# A maintainer still merges the PR; this only prepares it.
+name: Add versioned Homebrew formula
+
+on:
+  push:
+    branches: [goreleaser]
+    # Only react to GoReleaser's rolling-formula update. Our own commit below adds
+    # Formula/atlan@X.Y.Z.rb (not atlan.rb), so it does not re-trigger this workflow.
+    paths:
+      - Formula/atlan.rb
+
+permissions:
+  contents: write
+
+jobs:
+  add-versioned-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout goreleaser branch
+        uses: actions/checkout@v4
+        with:
+          ref: goreleaser
+          fetch-depth: 0
+
+      - name: Generate versioned formula
+        id: gen
+        run: |
+          set -euo pipefail
+
+          # Read the version GoReleaser wrote into the rolling formula.
+          VERSION="$(sed -n 's/^[[:space:]]*version "\(.*\)".*/\1/p' Formula/atlan.rb | head -1)"
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not read version from Formula/atlan.rb"; exit 1
+          fi
+
+          # Homebrew versioned-formula class name: AtlanAT<version-without-dots>
+          # e.g. 0.5.1 -> AtlanAT051, 0.1.10 -> AtlanAT0110.
+          CLASS="AtlanAT$(printf '%s' "$VERSION" | tr -d '.')"
+          TARGET="Formula/atlan@${VERSION}.rb"
+          echo "version=$VERSION class=$CLASS target=$TARGET"
+
+          if [ -f "$TARGET" ]; then
+            echo "$TARGET already exists — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Versioned formula = exact copy of the rolling formula with ONLY the
+          # class line renamed.
+          sed "s/^class Atlan < Formula/class ${CLASS} < Formula/" Formula/atlan.rb > "$TARGET"
+
+          # Fail loud if the rename didn't take (rolling formula not in the
+          # expected `class Atlan < Formula` shape).
+          if ! grep -q "^class ${CLASS} < Formula" "$TARGET"; then
+            echo "::error::class rename failed — Formula/atlan.rb is not in the expected 'class Atlan < Formula' shape"
+            rm -f "$TARGET"; exit 1
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push versioned formula
+        if: steps.gen.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add "${{ steps.gen.outputs.target }}"
+          git commit -m "chore: add versioned formula atlan@${{ steps.gen.outputs.version }}"
+          git push origin HEAD:goreleaser


### PR DESCRIPTION
## What & why

Closes **BLDX-1519** — *Create Atlan CLI auto-release automation pipeline.*

The atlan-cli release is already ~90% automated: merging a `version.txt` bump triggers `create-release.yml` → GoReleaser publishes the release and opens a PR here updating the rolling `Formula/atlan.rb`. The **one manual step left** is hand-adding the versioned `Formula/atlan@X.Y.Z.rb`. This PR automates exactly that.

## What it does

`.github/workflows/versioned-formula.yml` — when GoReleaser pushes the rolling `Formula/atlan.rb` to the `goreleaser` branch, this workflow adds `Formula/atlan@X.Y.Z.rb` onto the **same branch**, so it lands in the open GoReleaser PR ready for a maintainer to merge.

- The versioned file is an **exact copy** of `atlan.rb` with only the class line renamed to `AtlanAT<version-without-dots>` (`0.5.1 → AtlanAT051`, `0.1.10 → AtlanAT0110`) — the current convention (matches `atlan@0.4.0/0.5.0/0.5.1.rb`).
- **Trigger:** `push` to `goreleaser` touching `Formula/atlan.rb`. GoReleaser pushes with a PAT so its push fires this workflow; our own commit adds only the versioned file, so it does **not** re-trigger. Idempotent — skips if the versioned file already exists.
- **Fails loud** if `atlan.rb` isn't in the expected `class Atlan < Formula` shape (rather than silently producing a wrong formula).
- A maintainer still merges the Homebrew PR — this only prepares it.

## Verification

Ran the generation logic locally against the current `Formula/atlan.rb` (v0.5.1): the output is **byte-identical** to the human-authored `Formula/atlan@0.5.1.rb`. Double-digit patch edge case checked: `0.1.10 → AtlanAT0110`.

## One repo-setting prerequisite

The workflow commits back with the default `GITHUB_TOKEN` and declares `permissions: contents: write`. Please confirm **Settings → Actions → Workflow permissions** is set to *Read and write* (or that Actions may push to `goreleaser`). If org policy blocks `GITHUB_TOKEN` writes, I'll switch the push to a PAT secret — flag me.

Opening for review — not merging.

## How it fires (assumption to confirm)

A `push`-triggered workflow runs the workflow file **as it exists on the branch receiving the push** — so `versioned-formula.yml` must be present on the `goreleaser` branch when GoReleaser pushes. GoReleaser's brew publisher creates/updates the tap PR branch from the repo's **default branch**, so once this PR merges to `main`, the next release's `goreleaser` branch inherits the workflow and it fires. This can only be fully confirmed on the next real release; if your GoReleaser setup keeps a long-lived `goreleaser` branch that isn't re-synced from `main`, that branch may need a one-time sync so the workflow is present. Flagging so it's a conscious check, not a silent assumption.
